### PR TITLE
Initial implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+recharter*
+tmp*

--- a/DCO
+++ b/DCO
@@ -1,0 +1,36 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+660 York Street, Suite 102,
+San Francisco, CA 94110 USA
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2016 - 2021 Giant Swarm GmbH
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+# DO NOT EDIT. Generated with:
+#
+#    devctl@4.21.0
+#
+
+include Makefile.*.mk
+
+##@ General
+
+# The help target prints out all targets with their descriptions organized
+# beneath their categories. The categories are represented by '##@' and the
+# target descriptions by '##'. The awk commands is responsible for reading the
+# entire set of makefiles included in this invocation, looking for lines of the
+# file as xyz: ## something, and then pretty-format the target and help. Then,
+# if there's a line with ##@ something, that gets pretty-printed as a category.
+# More info on the usage of ANSI control characters for terminal formatting:
+# https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_parameters
+# More info on the awk command:
+# http://linuxcommand.org/lc3_adv_awk.php
+
+.PHONY: help
+help: ## Display this help.
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)

--- a/Makefile.gen.go.mk
+++ b/Makefile.gen.go.mk
@@ -1,0 +1,131 @@
+# DO NOT EDIT. Generated with:
+#
+#    devctl@4.21.0
+#
+
+PACKAGE_DIR    := ./bin-dist
+
+APPLICATION    := $(shell go list -m | cut -d '/' -f 3)
+BUILDTIMESTAMP := $(shell date -u '+%FT%TZ')
+GITSHA1        := $(shell git rev-parse --verify HEAD)
+MODULE         := $(shell go list -m)
+OS             := $(shell go env GOOS)
+SOURCES        := $(shell find . -name '*.go')
+VERSION        := $(shell architect project version)
+ifeq ($(OS), linux)
+EXTLDFLAGS := -static
+endif
+LDFLAGS        ?= -w -linkmode 'auto' -extldflags '$(EXTLDFLAGS)' \
+  -X '$(shell go list -m)/pkg/project.buildTimestamp=${BUILDTIMESTAMP}' \
+  -X '$(shell go list -m)/pkg/project.gitSHA=${GITSHA1}'
+
+.DEFAULT_GOAL := build
+
+##@ Go
+
+.PHONY: build build-darwin build-darwin-64 build-linux build-linux-arm64
+build: $(APPLICATION) ## Builds a local binary.
+	@echo "====> $@"
+build-darwin: $(APPLICATION)-darwin ## Builds a local binary for darwin/amd64.
+	@echo "====> $@"
+build-darwin-arm64: $(APPLICATION)-darwin-arm64 ## Builds a local binary for darwin/arm64.
+	@echo "====> $@"
+build-linux: $(APPLICATION)-linux ## Builds a local binary for linux/amd64.
+	@echo "====> $@"
+build-linux-arm64: $(APPLICATION)-linux-arm64 ## Builds a local binary for linux/arm64.
+	@echo "====> $@"
+
+$(APPLICATION): $(APPLICATION)-v$(VERSION)-$(OS)-amd64
+	@echo "====> $@"
+	cp -a $< $@
+
+$(APPLICATION)-darwin: $(APPLICATION)-v$(VERSION)-darwin-amd64
+	@echo "====> $@"
+	cp -a $< $@
+
+$(APPLICATION)-darwin-arm64: $(APPLICATION)-v$(VERSION)-darwin-arm64
+	@echo "====> $@"
+	cp -a $< $@
+
+$(APPLICATION)-linux: $(APPLICATION)-v$(VERSION)-linux-amd64
+	@echo "====> $@"
+	cp -a $< $@
+
+$(APPLICATION)-linux-arm64: $(APPLICATION)-v$(VERSION)-linux-arm64
+	@echo "====> $@"
+	cp -a $< $@
+
+$(APPLICATION)-v$(VERSION)-%-amd64: $(SOURCES)
+	@echo "====> $@"
+	CGO_ENABLED=0 GOOS=$* GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o $@ .
+
+$(APPLICATION)-v$(VERSION)-%-arm64: $(SOURCES)
+	@echo "====> $@"
+	CGO_ENABLED=0 GOOS=$* GOARCH=arm64 go build -ldflags "$(LDFLAGS)" -o $@ .
+
+.PHONY: package-darwin-amd64 package-darwin-arm64 package-linux-amd64 package-linux-arm64
+package-darwin-amd64: $(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-darwin-amd64.tar.gz ## Prepares a packaged darwin/amd64 version.
+	@echo "====> $@"
+package-darwin-arm64: $(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-darwin-arm64.tar.gz ## Prepares a packaged darwin/arm64 version.
+	@echo "====> $@"
+package-linux-amd64: $(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-linux-amd64.tar.gz ## Prepares a packaged linux/amd64 version.
+	@echo "====> $@"
+package-linux-arm64: $(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-linux-arm64.tar.gz ## Prepares a packaged linux/arm64 version.
+	@echo "====> $@"
+
+$(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-%-amd64.tar.gz: DIR=$(PACKAGE_DIR)/$<
+$(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-%-amd64.tar.gz: $(APPLICATION)-v$(VERSION)-%-amd64
+	@echo "====> $@"
+	mkdir -p $(DIR)
+	cp $< $(DIR)/$(APPLICATION)
+	cp README.md LICENSE $(DIR)
+	tar -C $(PACKAGE_DIR) -cvzf $(PACKAGE_DIR)/$<.tar.gz $<
+	rm -rf $(DIR)
+	rm -rf $<
+
+$(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-%-arm64.tar.gz: DIR=$(PACKAGE_DIR)/$<
+$(PACKAGE_DIR)/$(APPLICATION)-v$(VERSION)-%-arm64.tar.gz: $(APPLICATION)-v$(VERSION)-%-arm64
+	@echo "====> $@"
+	mkdir -p $(DIR)
+	cp $< $(DIR)/$(APPLICATION)
+	cp README.md LICENSE $(DIR)
+	tar -C $(PACKAGE_DIR) -cvzf $(PACKAGE_DIR)/$<.tar.gz $<
+	rm -rf $(DIR)
+	rm -rf $<
+
+.PHONY: install
+install: ## Install the application.
+	@echo "====> $@"
+	go install -ldflags "$(LDFLAGS)" .
+
+.PHONY: run
+run: ## Runs go run main.go.
+	@echo "====> $@"
+	go run -ldflags "$(LDFLAGS)" -race .
+
+.PHONY: clean
+clean: ## Cleans the binary.
+	@echo "====> $@"
+	rm -f $(APPLICATION)*
+	go clean
+
+.PHONY: imports
+imports: ## Runs goimports.
+	@echo "====> $@"
+	goimports -local $(MODULE) -w .
+
+.PHONY: lint
+lint: ## Runs golangci-lint.
+	@echo "====> $@"
+	golangci-lint run -E gosec -E goconst --timeout=15m ./...
+
+.PHONY: test
+test: ## Runs go test with default values.
+	@echo "====> $@"
+	go test -ldflags "$(LDFLAGS)" -race ./...
+
+.PHONY: build-docker
+build-docker: build-linux ## Builds docker image to registry.
+	@echo "====> $@"
+	cp -a $(APPLICATION)-linux $(APPLICATION)
+	docker build -t ${APPLICATION}:${VERSION} .

--- a/charts.yaml
+++ b/charts.yaml
@@ -1,0 +1,4 @@
+- name: "cilium"
+  versions: ">= 1.11.2"
+  srcHelmRepo: "https://helm.cilium.io"
+  dstCatalog: "default-test"

--- a/charts.yaml
+++ b/charts.yaml
@@ -1,4 +1,4 @@
-- name: "cilium"
+- chart: "cilium"
   versions: ">= 1.11.2"
   srcHelmRepo: "https://helm.cilium.io"
   dstCatalog: "default-test"

--- a/cmd/run/config.go
+++ b/cmd/run/config.go
@@ -23,7 +23,7 @@ func loadConfig(path string) ([]syncConfig, error) {
 }
 
 type syncConfig struct {
-	Name        string `json:"name"`
+	Chart       string `json:"chart"`
 	Versions    string `json:"versions"`
 	SrcHelmRepo string `json:"srcHelmRepo"`
 	DstCatalog  string `json:"dstCatalog"`

--- a/cmd/run/config.go
+++ b/cmd/run/config.go
@@ -1,0 +1,30 @@
+package run
+
+import (
+	"fmt"
+	"os"
+
+	"sigs.k8s.io/yaml"
+)
+
+func loadConfig(path string) ([]syncConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("loading configuration from %q: %w", path, err)
+	}
+
+	config := []syncConfig{}
+	err = yaml.Unmarshal(data, &config)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshaling YAML from %q: %w", path, err)
+	}
+
+	return config, nil
+}
+
+type syncConfig struct {
+	Name        string `json:"name"`
+	Versions    string `json:"versions"`
+	SrcHelmRepo string `json:"srcHelmRepo"`
+	DstCatalog  string `json:"dstCatalog"`
+}

--- a/cmd/run/flag.go
+++ b/cmd/run/flag.go
@@ -1,0 +1,27 @@
+package run
+
+import (
+	"errors"
+
+	flag "github.com/spf13/pflag"
+)
+
+var flags = flagsT{}
+
+type flagsT struct {
+	Config      string
+	SkipCleanup bool
+}
+
+func (f *flagsT) Parse() error {
+	flag.StringVar(&flags.Config, "config", "", "Path to the configuration file.")
+	flag.BoolVar(&f.SkipCleanup, "skip-cleanup", false, "Do not clean up temporary directories. Useful for debugging.")
+
+	flag.Parse()
+
+	if f.Config == "" {
+		return errors.New("--config flag is required")
+	}
+
+	return nil
+}

--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -1,0 +1,209 @@
+package run
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/giantswarm/recharter/pkg/shell"
+	"sigs.k8s.io/yaml"
+)
+
+const (
+	localHelmRepositoryName = "tmp-recharter"
+	tmpPrefix               = "./tmp-recharter"
+)
+
+func Run() (err error, exitCode int) {
+	err = flags.Parse()
+	if err != nil {
+		return err, 1
+	}
+
+	if !flags.SkipCleanup {
+		shell.Cmdf("rm -rf %s*", tmpPrefix).OrDie()
+		defer shell.Cmdf("rm -rf %s*", tmpPrefix).OrDie()
+	}
+
+	config, err := loadConfig(flags.Config)
+	if err != nil {
+		return err, 1
+	}
+
+	// Normalize catalog names.
+	for i, _ := range config {
+		config[i].DstCatalog = strings.TrimSuffix(config[i].DstCatalog, "-catalog") + "-catalog"
+	}
+
+	for _, c := range config {
+		err, exitCode := sync(c)
+		if err != nil {
+			return err, exitCode
+		}
+	}
+
+	return nil, 0
+}
+
+func sync(config syncConfig) (err error, exitCode int) {
+	// Download the catalog git repo.
+
+	gitURL := "git@github.com:giantswarm/" + config.DstCatalog + ".git"
+	shell.Cmdf("git clone --depth=1 %q ./tmp-recharter-catalog", gitURL).OrDie()
+
+	// Parse source and destination index.yaml.
+
+	srcIndexURL := strings.TrimSuffix(config.SrcHelmRepo, "/") + "/" + "index.yaml"
+	resp, err := http.Get(srcIndexURL)
+	if err != nil {
+		return fmt.Errorf("downloading %s: %w", srcIndexURL, err), 1
+	}
+	defer resp.Body.Close()
+
+	srcEntries, err := parseIndex(resp.Body, config.SrcHelmRepo, config.Versions)
+	if err != nil {
+		return fmt.Errorf("parsing source (%s) index: %w", srcIndexURL, err), 1
+	}
+
+	dstIndexPath := "./tmp-recharter-catalog/index.yaml"
+	file, err := os.Open(dstIndexPath)
+	if err != nil {
+		return fmt.Errorf("opening %s: %w", dstIndexPath, err), 1
+	}
+	defer file.Close()
+
+	catalogURL := "https://giantswarm.github.io/" + config.DstCatalog
+
+	dstEntries, err := parseIndex(file, catalogURL, "*")
+	if err != nil {
+		return fmt.Errorf("parsing destination (%s) index: %w", dstIndexPath, err), 1
+	}
+
+	// Pull releases which don't exist in the destination repository.
+
+	shell.Cmdf("mkdir ./tmp-recharter-tarballs").OrDie()
+
+	downloaded := false
+	for chart, infos := range srcEntries {
+		dstInfos := dstEntries[chart]
+
+		for _, srcInfo := range infos {
+			found := false
+			for _, dstInfo := range dstInfos {
+				if dstInfo.Version == srcInfo.Version {
+					found = true
+					break
+				}
+			}
+			if found {
+				fmt.Printf("--> Chart %s@%s found in the %q catalog, skipping\n", chart, srcInfo.Version, config.DstCatalog)
+			} else {
+				downloaded = true
+				res, err := http.Get(srcInfo.URL)
+				if err != nil {
+					return fmt.Errorf("downloading tarball from %q: %w", srcInfo.URL, err), 1
+				}
+				defer res.Body.Close()
+
+				tarballFile := "./tmp-recharter-tarballs/" + srcInfo.URL[strings.LastIndex(srcInfo.URL, "/")+1:]
+				file, err := os.OpenFile(tarballFile, os.O_CREATE|os.O_WRONLY, 0644)
+				if err != nil {
+					return fmt.Errorf("creating file %q: %w", tarballFile, err), 1
+				}
+				defer file.Close()
+
+				_, err = io.Copy(file, res.Body)
+				if err != nil {
+					return fmt.Errorf("copying response content to %q file: %w", tarballFile, err), 1
+				}
+
+				shell.Cmdf("helm pull %q --version=%q", chart, srcInfo.Version).
+					WithDir("./tmp-recharter-tarballs").
+					OrDie()
+			}
+		}
+	}
+
+	// If nothing was downloaded return early.
+
+	if !downloaded {
+		fmt.Printf("--> No new releases downloaded from %s\n", config.SrcHelmRepo)
+		return nil, 0
+	}
+
+	// Update the destination catalog index.yaml and move the downloaded tarballs.
+
+	shell.Cmdf("helm repo index --url=%q --merge=./tmp-recharter-catalog/index.yaml ./tmp-recharter-tarballs", catalogURL).OrDie()
+	shell.Cmdf("cp -a ./tmp-recharter-tarballs/* ./tmp-recharter-catalog").OrDie()
+
+	// Commit and push the destination catalog.
+
+	shell.Cmdf("git -C ./tmp-recharter-catalog add -A").OrDie()
+	shell.Cmdf("git -C ./tmp-recharter-catalog commit -m %q", "Pull "+config.SrcHelmRepo+" releases").OrDie()
+	shell.Cmdf("git -C ./tmp-recharter-catalog push").OrDie()
+
+	return nil, 0
+}
+
+// parseIndex returns a map where keys are chart names and values are lists of
+// versions of the charts.
+func parseIndex(data io.Reader, repoURL, versionRange string) (map[string][]releaseInfo, error) {
+	repoURL = strings.TrimSuffix(repoURL, "/index.yaml")
+	repoURL = strings.TrimSuffix(repoURL, "/")
+
+	versionConstraint, err := semver.NewConstraint(versionRange)
+	if err != nil {
+		return nil, fmt.Errorf("creating version constraint for %q: %w", versionRange, err)
+	}
+
+	index := struct {
+		Entries map[string][]struct {
+			Version string   `json:"version"`
+			URLs    []string `json:"urls"`
+		} `json:"entries"`
+	}{}
+
+	bytes, err := io.ReadAll(data)
+	if err != nil {
+		return nil, fmt.Errorf("reading index bytes: %w", err)
+	}
+	err = yaml.Unmarshal(bytes, &index)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshaling index YAML: %w", err)
+	}
+
+	res := make(map[string][]releaseInfo, len(index.Entries))
+
+	for chart, releases := range index.Entries {
+		var infos []releaseInfo
+		for _, r := range releases {
+			v, err := semver.NewVersion(r.Version)
+			if err != nil {
+				return nil, fmt.Errorf("parsing semver for %q: %w", r.Version, err)
+			}
+
+			if !versionConstraint.Check(v) {
+				continue
+			}
+
+			if len(r.URLs) == 0 {
+				return nil, fmt.Errorf("no URLs found for %s@%s", chart, r.Version)
+			}
+			url := r.URLs[0]
+			if !strings.HasPrefix(url, "http://") && !strings.HasPrefix(url, "https://") {
+				url = repoURL + "/" + url
+			}
+			info := releaseInfo{
+				Version: r.Version,
+				URL:     url,
+			}
+			infos = append(infos, info)
+		}
+		res[chart] = infos
+	}
+
+	return res, nil
+}

--- a/cmd/run/types.go
+++ b/cmd/run/types.go
@@ -1,0 +1,6 @@
+package run
+
+type releaseInfo struct {
+	Version string
+	URL     string
+}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,9 @@ module github.com/giantswarm/recharter
 go 1.17
 
 require (
-	github.com/spf13/pflag v1.0.5 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
-	sigs.k8s.io/yaml v1.3.0 // indirect
+	github.com/Masterminds/semver/v3 v3.1.1
+	github.com/spf13/pflag v1.0.5
+	sigs.k8s.io/yaml v1.3.0
 )
+
+require gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module github.com/giantswarm/recharter
+
+go 1.17
+
+require (
+	github.com/spf13/pflag v1.0.5 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	sigs.k8s.io/yaml v1.3.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
+sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=
+sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,10 @@
+github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
+github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/main.go
+++ b/main.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+
+	flag "github.com/spf13/pflag"
+)
+
+const (
+	localHelmRepositoryName = "tmp-recharter"
+)
+
+var options = optionsT{}
+
+var flags = flagsT{}
+
+func main() {
+	err, code := mainE()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %s\n", err)
+	}
+	os.Exit(code)
+}
+
+func mainE() (err error, exitCode int) {
+	err = flags.Parse()
+	if err != nil {
+		return err, 1
+	}
+
+	if !flags.SkipCleanup {
+		sh("rm -rf ./tmp-recharter*")
+		defer sh("rm -rf ./tmp-recharter*")
+	}
+
+	sh(fmt.Sprintf("helm repo add %s https://helm.cilium.io/", localHelmRepositoryName))
+	defer sh(fmt.Sprintf("helm repo remove %s", localHelmRepositoryName))
+
+	var releasesJson []byte
+	sh(fmt.Sprintf("helm search repo --versions --version=%q -o json %q", flags.ReleaseVersion, localHelmRepositoryName),
+		options.CaptureStdoutTo(&releasesJson),
+	)
+
+	releases := []struct {
+		Name    string `json:"name"`
+		Version string `json:"version"`
+	}{}
+	err = json.Unmarshal(releasesJson, &releases)
+	if err != nil {
+		return fmt.Errorf("unmarshaling releases JSON: %w", err), 1
+	}
+
+	sh("mkdir ./tmp-recharter-tarballs")
+	for _, r := range releases {
+		sh(fmt.Sprintf("helm pull %q --version=%q", r.Name, r.Version),
+			options.Dir("./tmp-recharter-tarballs"),
+		)
+	}
+
+	gitURL := "git@github.com:giantswarm/" + flags.Catalog + ".git"
+	sh(fmt.Sprintf("git clone --depth=1 %q ./tmp-recharter-catalog", gitURL))
+
+	catalogURL := "https://giantswarm.github.io/" + flags.Catalog
+	sh(fmt.Sprintf("helm repo index --url=%q --merge=./tmp-recharter-catalog/index.yaml ./tmp-recharter-tarballs", catalogURL))
+	sh("cp -a ./tmp-recharter-tarballs/* ./tmp-recharter-catalog")
+
+	sh("git -C ./tmp-recharter-catalog add -A")
+	sh(fmt.Sprintf("git -C ./tmp-recharter-catalog commit -m %q", "Pull "+flags.RepoURL+" releases"))
+	sh("git -C ./tmp-recharter-catalog push")
+
+	return nil, 0
+}
+
+func sh(command string, opts ...option) {
+	fmt.Printf("--> %s\n", command)
+
+	cmd := exec.Command("sh", "-c", command)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	for _, o := range opts {
+		o.PreRun(cmd)
+	}
+	err := cmd.Run()
+	var eerr *exec.ExitError
+	if err != nil && errors.As(err, &eerr) {
+		os.Exit(eerr.ExitCode())
+	} else if err != nil {
+		fmt.Fprintf(os.Stderr, "error executing command: %s\n", err)
+		os.Exit(1)
+	}
+	for _, o := range opts {
+		o.PostRun(cmd)
+	}
+}
+
+type flagsT struct {
+	RepoURL        string
+	Catalog        string
+	ReleaseVersion string
+	SkipCleanup    bool
+}
+
+func (f *flagsT) Parse() error {
+	flag.StringVar(&flags.RepoURL, "repo-url", "", "Source Helm repository URL.")
+	flag.StringVar(&flags.Catalog, "catalog", "", "App Catalog name to push the chart to.")
+	flag.StringVar(&flags.ReleaseVersion, "release-version", "", "Filter releases using semantic versioning constraints, e.g. \"^1.0.0\".")
+	flag.BoolVar(&f.SkipCleanup, "skip-cleanup", false, "Do not clean up temporary directories. Useful for debugging.")
+
+	flag.Parse()
+
+	if f.RepoURL == "" {
+		return errors.New("--repo-url flag is required")
+	}
+	if f.Catalog == "" {
+		return errors.New("--catalog flag is required")
+	}
+
+	return nil
+}
+
+type option interface {
+	PreRun(*exec.Cmd)
+	PostRun(*exec.Cmd)
+}
+
+type optionsT struct{}
+
+// CaptureStdoutTo captures to output of the stdout to the provided slice.
+func (optionsT) CaptureStdoutTo(bs *[]byte) *captureStdoutToOption {
+	return &captureStdoutToOption{bs: bs}
+}
+
+// Dir sets the current working directory of the command.
+func (optionsT) Dir(dir string) *dirOption {
+	return &dirOption{dir: dir}
+}
+
+type captureStdoutToOption struct {
+	bs  *[]byte
+	buf *bytes.Buffer
+}
+
+func (o *captureStdoutToOption) PreRun(cmd *exec.Cmd) {
+	o.buf = new(bytes.Buffer)
+	cmd.Stdout = o.buf
+}
+
+func (o *captureStdoutToOption) PostRun(cmd *exec.Cmd) {
+	*o.bs = o.buf.Bytes()
+}
+
+type dirOption struct {
+	dir string
+}
+
+func (o *dirOption) PreRun(cmd *exec.Cmd) {
+	cmd.Dir = o.dir
+}
+
+func (o *dirOption) PostRun(cmd *exec.Cmd) {
+}

--- a/main.go
+++ b/main.go
@@ -1,167 +1,27 @@
 package main
 
 import (
-	"bytes"
-	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
-	"os/exec"
+	"path/filepath"
 
-	flag "github.com/spf13/pflag"
+	"github.com/giantswarm/recharter/cmd/run"
 )
-
-const (
-	localHelmRepositoryName = "tmp-recharter"
-)
-
-var options = optionsT{}
-
-var flags = flagsT{}
 
 func main() {
-	err, code := mainE()
+	// This is for the future if we decide to add more commands.
+	if len(os.Args) < 2 || os.Args[1] != "run" {
+		name := filepath.Base(os.Args[0])
+		fmt.Fprintf(os.Stderr, "usage: %s run [FLAGS]\n", name)
+		os.Exit(1)
+	}
+
+	// For the flag parsing in the command.
+	os.Args = os.Args[1:]
+
+	err, code := run.Run()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %s\n", err)
 	}
 	os.Exit(code)
-}
-
-func mainE() (err error, exitCode int) {
-	err = flags.Parse()
-	if err != nil {
-		return err, 1
-	}
-
-	if !flags.SkipCleanup {
-		sh("rm -rf ./tmp-recharter*")
-		defer sh("rm -rf ./tmp-recharter*")
-	}
-
-	sh(fmt.Sprintf("helm repo add %s https://helm.cilium.io/", localHelmRepositoryName))
-	defer sh(fmt.Sprintf("helm repo remove %s", localHelmRepositoryName))
-
-	var releasesJson []byte
-	sh(fmt.Sprintf("helm search repo --versions --version=%q -o json %q", flags.ReleaseVersion, localHelmRepositoryName),
-		options.CaptureStdoutTo(&releasesJson),
-	)
-
-	releases := []struct {
-		Name    string `json:"name"`
-		Version string `json:"version"`
-	}{}
-	err = json.Unmarshal(releasesJson, &releases)
-	if err != nil {
-		return fmt.Errorf("unmarshaling releases JSON: %w", err), 1
-	}
-
-	sh("mkdir ./tmp-recharter-tarballs")
-	for _, r := range releases {
-		sh(fmt.Sprintf("helm pull %q --version=%q", r.Name, r.Version),
-			options.Dir("./tmp-recharter-tarballs"),
-		)
-	}
-
-	gitURL := "git@github.com:giantswarm/" + flags.Catalog + ".git"
-	sh(fmt.Sprintf("git clone --depth=1 %q ./tmp-recharter-catalog", gitURL))
-
-	catalogURL := "https://giantswarm.github.io/" + flags.Catalog
-	sh(fmt.Sprintf("helm repo index --url=%q --merge=./tmp-recharter-catalog/index.yaml ./tmp-recharter-tarballs", catalogURL))
-	sh("cp -a ./tmp-recharter-tarballs/* ./tmp-recharter-catalog")
-
-	sh("git -C ./tmp-recharter-catalog add -A")
-	sh(fmt.Sprintf("git -C ./tmp-recharter-catalog commit -m %q", "Pull "+flags.RepoURL+" releases"))
-	sh("git -C ./tmp-recharter-catalog push")
-
-	return nil, 0
-}
-
-func sh(command string, opts ...option) {
-	fmt.Printf("--> %s\n", command)
-
-	cmd := exec.Command("sh", "-c", command)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-
-	for _, o := range opts {
-		o.PreRun(cmd)
-	}
-	err := cmd.Run()
-	var eerr *exec.ExitError
-	if err != nil && errors.As(err, &eerr) {
-		os.Exit(eerr.ExitCode())
-	} else if err != nil {
-		fmt.Fprintf(os.Stderr, "error executing command: %s\n", err)
-		os.Exit(1)
-	}
-	for _, o := range opts {
-		o.PostRun(cmd)
-	}
-}
-
-type flagsT struct {
-	RepoURL        string
-	Catalog        string
-	ReleaseVersion string
-	SkipCleanup    bool
-}
-
-func (f *flagsT) Parse() error {
-	flag.StringVar(&flags.RepoURL, "repo-url", "", "Source Helm repository URL.")
-	flag.StringVar(&flags.Catalog, "catalog", "", "App Catalog name to push the chart to.")
-	flag.StringVar(&flags.ReleaseVersion, "release-version", "", "Filter releases using semantic versioning constraints, e.g. \"^1.0.0\".")
-	flag.BoolVar(&f.SkipCleanup, "skip-cleanup", false, "Do not clean up temporary directories. Useful for debugging.")
-
-	flag.Parse()
-
-	if f.RepoURL == "" {
-		return errors.New("--repo-url flag is required")
-	}
-	if f.Catalog == "" {
-		return errors.New("--catalog flag is required")
-	}
-
-	return nil
-}
-
-type option interface {
-	PreRun(*exec.Cmd)
-	PostRun(*exec.Cmd)
-}
-
-type optionsT struct{}
-
-// CaptureStdoutTo captures to output of the stdout to the provided slice.
-func (optionsT) CaptureStdoutTo(bs *[]byte) *captureStdoutToOption {
-	return &captureStdoutToOption{bs: bs}
-}
-
-// Dir sets the current working directory of the command.
-func (optionsT) Dir(dir string) *dirOption {
-	return &dirOption{dir: dir}
-}
-
-type captureStdoutToOption struct {
-	bs  *[]byte
-	buf *bytes.Buffer
-}
-
-func (o *captureStdoutToOption) PreRun(cmd *exec.Cmd) {
-	o.buf = new(bytes.Buffer)
-	cmd.Stdout = o.buf
-}
-
-func (o *captureStdoutToOption) PostRun(cmd *exec.Cmd) {
-	*o.bs = o.buf.Bytes()
-}
-
-type dirOption struct {
-	dir string
-}
-
-func (o *dirOption) PreRun(cmd *exec.Cmd) {
-	cmd.Dir = o.dir
-}
-
-func (o *dirOption) PostRun(cmd *exec.Cmd) {
 }

--- a/pkg/shell/opt.go
+++ b/pkg/shell/opt.go
@@ -1,0 +1,36 @@
+package shell
+
+import (
+	"bytes"
+	"os/exec"
+)
+
+type option interface {
+	PreRun(*exec.Cmd)
+	PostRun(*exec.Cmd)
+}
+
+type captureStdoutToOption struct {
+	bs  *[]byte
+	buf *bytes.Buffer
+}
+
+func (o *captureStdoutToOption) PreRun(cmd *exec.Cmd) {
+	o.buf = new(bytes.Buffer)
+	cmd.Stdout = o.buf
+}
+
+func (o *captureStdoutToOption) PostRun(cmd *exec.Cmd) {
+	*o.bs = o.buf.Bytes()
+}
+
+type dirOption struct {
+	dir string
+}
+
+func (o *dirOption) PreRun(cmd *exec.Cmd) {
+	cmd.Dir = o.dir
+}
+
+func (o *dirOption) PostRun(cmd *exec.Cmd) {
+}

--- a/pkg/shell/shell.go
+++ b/pkg/shell/shell.go
@@ -1,0 +1,57 @@
+package shell
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+type Builder struct {
+	command string
+	options []option
+}
+
+func Cmdf(format string, a ...interface{}) *Builder {
+	return &Builder{
+		command: fmt.Sprintf(format, a...),
+	}
+}
+
+// WithCaptureStdoutTo option captures to output of the stdout to the provided
+// slice.
+func (b *Builder) WithCaptureStdoutTo(bs *[]byte) *Builder {
+	o := &captureStdoutToOption{bs: bs}
+	b.options = append(b.options, o)
+	return b
+}
+
+// WithDir option sets the current working directory of the command.
+func (b *Builder) WithDir(dir string) *Builder {
+	o := &dirOption{dir: dir}
+	b.options = append(b.options, o)
+	return b
+}
+
+func (b *Builder) OrDie() {
+	fmt.Printf("--> %s\n", b.command)
+
+	cmd := exec.Command("sh", "-c", b.command)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	for _, o := range b.options {
+		o.PreRun(cmd)
+	}
+	err := cmd.Run()
+	var eerr *exec.ExitError
+	if err != nil && errors.As(err, &eerr) {
+		os.Exit(eerr.ExitCode())
+	} else if err != nil {
+		fmt.Fprintf(os.Stderr, "error executing command: %s\n", err)
+		os.Exit(1)
+	}
+	for _, o := range b.options {
+		o.PostRun(cmd)
+	}
+}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/20946

There is much to improve here, but I wanted to keep to implementation as simple as possible for the first iteration.

Output for config:

```yaml
- chart: "cilium"
  versions: ">= 1.11.2"
  srcHelmRepo: "https://helm.cilium.io"
  dstCatalog: "default-test"
- chart: "does-not-exist"
  versions: ">= 1.2.3"
  srcHelmRepo: "https://example.com"
  dstCatalog: "default-test"
```

```
====> Cloning destination catalogs
--> Shell: git clone --depth=1 "git@github.com:giantswarm/default-test-catalog.git" ./tmp-recharter-catalog
Cloning into './tmp-recharter-catalog'...
remote: Enumerating objects: 1483, done.
remote: Counting objects: 100% (1483/1483), done.
remote: Compressing objects: 100% (1335/1335), done.
remote: Total 1483 (delta 236), reused 1371 (delta 145), pack-reused 0
Receiving objects: 100% (1483/1483), 23.36 MiB | 1.02 MiB/s, done.
Resolving deltas: 100% (236/236), done.
====> Synchronizing "cilium" with versions ">= 1.11.2" from https://helm.cilium.io to "default-test-catalog"
--> Shell: mkdir ./tmp-recharter-tarballs
--> Chart cilium@1.11.2 found in the "default-test-catalog" catalog, skipping
--> No new releases downloaded from https://helm.cilium.io
====> Synchronizing "does-not-exist" with versions ">= 1.2.3" from https://example.com to "default-test-catalog"
error: parsing source (https://example.com/index.yaml) index: unmarshaling index YAML: error converting YAML to JSON: yaml: line 11: mapping values are not allowed in this context
```